### PR TITLE
Update org.openttd.OpenTTD.yaml

### DIFF
--- a/org.openttd.OpenTTD.metainfo.xml
+++ b/org.openttd.OpenTTD.metainfo.xml
@@ -36,6 +36,7 @@
     <binary>openttd</binary>
   </provides>
   <releases>
+    <release version="13.4" date="2023-08-05"/>
     <release version="13.3" date="2023-06-11"/>
     <release version="13.2.1" date="2023-06-11"/>
     <release version="13.2" date="2023-06-10"/>

--- a/org.openttd.OpenTTD.yaml
+++ b/org.openttd.OpenTTD.yaml
@@ -57,8 +57,8 @@ modules:
       - install -D -m 644 -t $FLATPAK_DEST/share/metainfo ../org.openttd.OpenTTD.metainfo.xml
     sources:
       - type: archive
-        url: https://cdn.openttd.org/openttd-releases/13.3/openttd-13.3-source.tar.xz
-        sha256: aafa16d2fb67165134c73a888f79f7a5ed7da17a04cf6e9ecf672c9cb89e7192
+        url: https://cdn.openttd.org/openttd-releases/13.4/openttd-13.4-source.tar.xz
+        sha256: 2a1deba01bfe58e2188879f450c3fa4f3819271ab49bf348dd66545f040d146f
         x-checker-data:
           type: anitya
           project-id: 8640

--- a/org.openttd.OpenTTD.yaml
+++ b/org.openttd.OpenTTD.yaml
@@ -12,6 +12,7 @@ finish-args:
   - --share=network
   - --socket=pulseaudio
   - --socket=wayland
+  - --socket=x11
 modules:
   - shared-modules/SDL2/SDL2-with-libdecor.json
 


### PR DESCRIPTION
Allow using of x11, since not all pcs use wayland yet.

Note: i tested this quickly using flatseal to give openttd the permission.